### PR TITLE
docs: replace third party datetime picker with native browser picker

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: install
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "angular-ecmascript-intl-monorepo",
       "version": "0.0.0",
       "dependencies": {
-        "@angular-material-components/datetime-picker": "^9.0.0",
         "@angular/animations": "^16.0.0",
         "@angular/cdk": "^16.0.0",
         "@angular/common": "^16.0.0",
@@ -367,22 +366,6 @@
       "peerDependencies": {
         "eslint": "^7.20.0 || ^8.0.0",
         "typescript": "*"
-      }
-    },
-    "node_modules/@angular-material-components/datetime-picker": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-material-components/datetime-picker/-/datetime-picker-9.0.0.tgz",
-      "integrity": "sha512-F+yf5kxzu62q1H2ZiVbKGfKHlszQhYN/avZyejCyq7bI7V9kg93BaTJ+ACOf9NEtM05USzrLXdiBGjEAMW82aQ==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/cdk": "^15.0.1",
-        "@angular/common": "^15.0.1",
-        "@angular/core": "^15.0.1",
-        "@angular/forms": "^15.0.1",
-        "@angular/material": "^15.0.1",
-        "@angular/platform-browser": "^15.0.1"
       }
     },
     "node_modules/@angular/animations": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,12 +65,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1600.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1600.3.tgz",
-      "integrity": "sha512-XEncYhrQDwHjDBWqSv9oeufzsYQNHVP+ftD0LWtqL4TvOwsJ5ShWEqkjXIfG9FiaIUtmd6X2BBXutbib/yALxA==",
+      "version": "0.1600.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1600.4.tgz",
+      "integrity": "sha512-wW35EURt4QQhOTuQoMQ91Y9Jt7Fm4fs7KCUIQpkGisVu3P79TRgWyXUKv5IBXzLMGC3aJDv25zbLRchP+4Y7uA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.0.3",
+        "@angular-devkit/core": "16.0.4",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -80,15 +80,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-16.0.3.tgz",
-      "integrity": "sha512-AMxxrK0eMN7s6N4nxq0ZvyVIKwBD6L0xEb3kHOCt6BSSy7KdKnc3hTjB6ozQuzZog01xqtIfS87jsVA8WoRD2Q==",
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-16.0.4.tgz",
+      "integrity": "sha512-avNUNuLFSJOJ52z4Yk/5yyMVlMdpqbhPqW+RdinYrBRjkJZoscndV1bshrLZQHmVvoUpJes0mLXa1u+NRhqd3Q==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.1",
-        "@angular-devkit/architect": "0.1600.3",
-        "@angular-devkit/build-webpack": "0.1600.3",
-        "@angular-devkit/core": "16.0.3",
+        "@angular-devkit/architect": "0.1600.4",
+        "@angular-devkit/build-webpack": "0.1600.4",
+        "@angular-devkit/core": "16.0.4",
         "@babel/core": "7.21.4",
         "@babel/generator": "7.21.4",
         "@babel/helper-annotate-as-pure": "7.18.6",
@@ -100,7 +100,7 @@
         "@babel/runtime": "7.21.0",
         "@babel/template": "7.20.7",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "16.0.3",
+        "@ngtools/webpack": "16.0.4",
         "@vitejs/plugin-basic-ssl": "1.0.1",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.14",
@@ -208,12 +208,12 @@
       "dev": true
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1600.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1600.3.tgz",
-      "integrity": "sha512-b9AO5Kk+uOIK65x9IY1hTNCBs81G681qYRP1kmH8hD0yCC89l+dm0zM+D18s7syWJGem+1iSmceX2D5IOOVstg==",
+      "version": "0.1600.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1600.4.tgz",
+      "integrity": "sha512-MBUeVpZOTGGwT088mH2gEUF0w+8vrtZN1vQL1HLKHZoKEiuGBvixv+nQemUcN7dWJdOt1T+Q/UzPo5BD1u7kvw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1600.3",
+        "@angular-devkit/architect": "0.1600.4",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -227,9 +227,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.0.3.tgz",
-      "integrity": "sha512-3Epwyl0jlLP4X1hT8rl6fF66aGX6a/OvERvDFyaSI5fgMmiO/mN44JXeew9G6OE8XFQoV/cofrroYQ+Ugy+nJw==",
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.0.4.tgz",
+      "integrity": "sha512-RK8+W+BVQcD2RHyQcy4iKSIFO1BexVUU2htu3+A9SY7VN/szoMgHIP/sx7Pj+LIJfDrvyve57aIOv0KPWk3WOg==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -253,12 +253,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-16.0.3.tgz",
-      "integrity": "sha512-mWvEKtuWi8GjplhdogJ48e8/19Fa6JjyFvRJulZNFUpxfAUUTOAJ1e5FuxbK9mwD2f2NGOJf0/6wIl9ldj4jUg==",
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-16.0.4.tgz",
+      "integrity": "sha512-ASr9bGRuTTAAgHsr/ltBBl4CTyZETmuzS/boVMNDVLvjDDFr0aY/F/FW/QRFbJsxgxM2VAJn7NpY64Rl9fQz/g==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.0.3",
+        "@angular-devkit/core": "16.0.4",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.30.0",
         "ora": "5.4.1",
@@ -369,9 +369,9 @@
       }
     },
     "node_modules/@angular/animations": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-16.0.3.tgz",
-      "integrity": "sha512-YKy3ECR3+Os1viw3FhBJ+pUqPTACGB1sxeZ2LYCX8LLynpetQ/yQQWQUYDGXEZQJrXlnnDS8QDlebEIvk1hCcQ==",
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-16.0.4.tgz",
+      "integrity": "sha512-M0C21mav4gtzWrWf6zTAYImL+Vix0bEDM/FF9ktmm04yt3Y8VtcMeDNRQRLj6JTIbth/fyvKZ20HSYFD91ez2g==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -379,13 +379,13 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.0.3"
+        "@angular/core": "16.0.4"
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-16.0.2.tgz",
-      "integrity": "sha512-wspHIYEnYPDBcDldm3tKJU3FJW/M6fB0N+ja+79Amo3+yQBpkr57mfjRYaLGaPZeHXsRah8y+P7YGj6I8NN7Pw==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-16.0.3.tgz",
+      "integrity": "sha512-KQCKWWNiHuYmzAVSiEyVs1P+859uhlvnmUH2azoL3qUHUcvdyB+iYqv9rTVRJl4N8nOpOYrj4JP3zmvNZLsI1Q==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -399,15 +399,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.0.3.tgz",
-      "integrity": "sha512-yZQSfjxy1Tw2nAU5q1NEiE+qGDfVSqFJPptsRSi8C1DhOtwFI4mCbUjdX9l8X+J3y+trKCyaTtPhljs12TQrWg==",
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.0.4.tgz",
+      "integrity": "sha512-6+gULiKzETlB/iTjhDBAnDYY7od34kKyFQE9X/p2DejslMtRweuj7/A8RueVpTR7fIDkWH1aBeZgqIWjj/8eVw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1600.3",
-        "@angular-devkit/core": "16.0.3",
-        "@angular-devkit/schematics": "16.0.3",
-        "@schematics/angular": "16.0.3",
+        "@angular-devkit/architect": "0.1600.4",
+        "@angular-devkit/core": "16.0.4",
+        "@angular-devkit/schematics": "16.0.4",
+        "@schematics/angular": "16.0.4",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.0.0",
@@ -433,9 +433,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.0.3.tgz",
-      "integrity": "sha512-pN1Mz2xwPs9+W3i+wBletdPMJC+exP9dCdy+iSG5pwpvii1jF3CbstHAPE/pmsoUlQ9nN+vrFowDAXVV7FQpWw==",
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.0.4.tgz",
+      "integrity": "sha512-EX1u46Lwc0uGcc0jjaxFHcnkuXusytYcjcd9pc+7eNNIi9nvLJDRmd8VyZ12ozc6ynBO6vt0mFSpIpjUVsTheQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -443,14 +443,14 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.0.3",
+        "@angular/core": "16.0.4",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.0.3.tgz",
-      "integrity": "sha512-LF/AS0bFXQ+qn6a8Ogx5nNHTYxf+OUYLXQYWECrKCJ4HSsouKDmQ/k8UPlh0gWt9NqQ4SPp9mNpzQhQ4Hq+rXw==",
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.0.4.tgz",
+      "integrity": "sha512-TTCuvkODBsbm6H1xleUQy60ITaUIdD/b2smm2OHlMw0QPJOfC75DG0uwIjsHA5KjZNlLyRBQKAxrc8cYhMpyoQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -458,7 +458,7 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/core": "16.0.3"
+        "@angular/core": "16.0.4"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -467,9 +467,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.0.3.tgz",
-      "integrity": "sha512-h4dnQqvaXOqNWiNgnolahKRoArVJ3r0DW27lTru4eSrnYv+Pd1cDAlBihEJq1Yk76W9wFCN3UjtRwkb1d1ZjUg==",
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.0.4.tgz",
+      "integrity": "sha512-sCwB6GVvadrp9CQDC1cm/Hcmv0so2zZ6K1hLiFqi5ZbqelzAtTmvGxhTyQEAX1ZC7hdrpvhWm1Sqbh08OD4cdA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.21.8",
@@ -490,7 +490,7 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "16.0.3",
+        "@angular/compiler": "16.0.4",
         "typescript": ">=4.9.3 <5.1"
       }
     },
@@ -549,9 +549,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.0.3.tgz",
-      "integrity": "sha512-vaUOLgDk03aKDHX6jtv4NEDB6gEBCXvgTpvsTmDUXcCa9WxyXs4Ak22q9ZyNln8/7UG5Uo1gTn90FlOAh9jHww==",
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.0.4.tgz",
+      "integrity": "sha512-Lp/qGJt0NFFTKQHofaMjCdGYfVwGCyhBtcbioaTqi1wA5OwXfMZX5MgHZXl1KlnZs1YVqM8vO/Z/4kOxgYXvNQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -564,9 +564,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-16.0.3.tgz",
-      "integrity": "sha512-bCDD17HO9yzKNo4dFJm1doHDlkeBJaIrZKOEtwU6GJ4UcfhBV/xS+upYzZggj4SRIcKbu+ivWhoNGSJS3Lgo/w==",
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-16.0.4.tgz",
+      "integrity": "sha512-QkOM7xEYd4N0kXr1h2ma/R+TnkNGxNIyHNZNFMcTiWiJpzBkUiDJxurlm0Tdn/h5g/smY3zY0PFflQE5wpohNQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -574,69 +574,69 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "16.0.3",
-        "@angular/core": "16.0.3",
-        "@angular/platform-browser": "16.0.3",
+        "@angular/common": "16.0.4",
+        "@angular/core": "16.0.4",
+        "@angular/platform-browser": "16.0.4",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/material": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-16.0.2.tgz",
-      "integrity": "sha512-0bOWXfKsSDiRP39Nv4mJr85G6dChJTI3sNx5g9aWb88il0AiJP0CjgVqMkjoPlzNEcxewWJ8EEPGHf2maszNFQ==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-16.0.3.tgz",
+      "integrity": "sha512-iK3SpYKE7V2yeN7IfiLKusdQdJyYh+AD7U+0CWlgR3ejbmBiw+FTDxxbjOVAr14qI26vTqrKFf83lOkEm6m+Hg==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/auto-init": "15.0.0-canary.576d3d2c8.0",
-        "@material/banner": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/button": "15.0.0-canary.576d3d2c8.0",
-        "@material/card": "15.0.0-canary.576d3d2c8.0",
-        "@material/checkbox": "15.0.0-canary.576d3d2c8.0",
-        "@material/chips": "15.0.0-canary.576d3d2c8.0",
-        "@material/circular-progress": "15.0.0-canary.576d3d2c8.0",
-        "@material/data-table": "15.0.0-canary.576d3d2c8.0",
-        "@material/density": "15.0.0-canary.576d3d2c8.0",
-        "@material/dialog": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/drawer": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/fab": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/floating-label": "15.0.0-canary.576d3d2c8.0",
-        "@material/form-field": "15.0.0-canary.576d3d2c8.0",
-        "@material/icon-button": "15.0.0-canary.576d3d2c8.0",
-        "@material/image-list": "15.0.0-canary.576d3d2c8.0",
-        "@material/layout-grid": "15.0.0-canary.576d3d2c8.0",
-        "@material/line-ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/linear-progress": "15.0.0-canary.576d3d2c8.0",
-        "@material/list": "15.0.0-canary.576d3d2c8.0",
-        "@material/menu": "15.0.0-canary.576d3d2c8.0",
-        "@material/menu-surface": "15.0.0-canary.576d3d2c8.0",
-        "@material/notched-outline": "15.0.0-canary.576d3d2c8.0",
-        "@material/radio": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/segmented-button": "15.0.0-canary.576d3d2c8.0",
-        "@material/select": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/slider": "15.0.0-canary.576d3d2c8.0",
-        "@material/snackbar": "15.0.0-canary.576d3d2c8.0",
-        "@material/switch": "15.0.0-canary.576d3d2c8.0",
-        "@material/tab": "15.0.0-canary.576d3d2c8.0",
-        "@material/tab-bar": "15.0.0-canary.576d3d2c8.0",
-        "@material/tab-indicator": "15.0.0-canary.576d3d2c8.0",
-        "@material/tab-scroller": "15.0.0-canary.576d3d2c8.0",
-        "@material/textfield": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/tooltip": "15.0.0-canary.576d3d2c8.0",
-        "@material/top-app-bar": "15.0.0-canary.576d3d2c8.0",
-        "@material/touch-target": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/auto-init": "15.0.0-canary.90291f2e2.0",
+        "@material/banner": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/button": "15.0.0-canary.90291f2e2.0",
+        "@material/card": "15.0.0-canary.90291f2e2.0",
+        "@material/checkbox": "15.0.0-canary.90291f2e2.0",
+        "@material/chips": "15.0.0-canary.90291f2e2.0",
+        "@material/circular-progress": "15.0.0-canary.90291f2e2.0",
+        "@material/data-table": "15.0.0-canary.90291f2e2.0",
+        "@material/density": "15.0.0-canary.90291f2e2.0",
+        "@material/dialog": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/drawer": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/fab": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/floating-label": "15.0.0-canary.90291f2e2.0",
+        "@material/form-field": "15.0.0-canary.90291f2e2.0",
+        "@material/icon-button": "15.0.0-canary.90291f2e2.0",
+        "@material/image-list": "15.0.0-canary.90291f2e2.0",
+        "@material/layout-grid": "15.0.0-canary.90291f2e2.0",
+        "@material/line-ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/linear-progress": "15.0.0-canary.90291f2e2.0",
+        "@material/list": "15.0.0-canary.90291f2e2.0",
+        "@material/menu": "15.0.0-canary.90291f2e2.0",
+        "@material/menu-surface": "15.0.0-canary.90291f2e2.0",
+        "@material/notched-outline": "15.0.0-canary.90291f2e2.0",
+        "@material/radio": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/segmented-button": "15.0.0-canary.90291f2e2.0",
+        "@material/select": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/slider": "15.0.0-canary.90291f2e2.0",
+        "@material/snackbar": "15.0.0-canary.90291f2e2.0",
+        "@material/switch": "15.0.0-canary.90291f2e2.0",
+        "@material/tab": "15.0.0-canary.90291f2e2.0",
+        "@material/tab-bar": "15.0.0-canary.90291f2e2.0",
+        "@material/tab-indicator": "15.0.0-canary.90291f2e2.0",
+        "@material/tab-scroller": "15.0.0-canary.90291f2e2.0",
+        "@material/textfield": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/tooltip": "15.0.0-canary.90291f2e2.0",
+        "@material/top-app-bar": "15.0.0-canary.90291f2e2.0",
+        "@material/touch-target": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "@angular/animations": "^16.0.0 || ^17.0.0",
-        "@angular/cdk": "16.0.2",
+        "@angular/cdk": "16.0.3",
         "@angular/common": "^16.0.0 || ^17.0.0",
         "@angular/core": "^16.0.0 || ^17.0.0",
         "@angular/forms": "^16.0.0 || ^17.0.0",
@@ -645,9 +645,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.0.3.tgz",
-      "integrity": "sha512-3YzRixYdmFhmTauHhnwLAHq1SOmHCk2VfUYsSfGyZM71DGMGXvUYVPZ00IE1+Hoh61ulv9do4+FDcGhB+r2Huw==",
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.0.4.tgz",
+      "integrity": "sha512-sU9ZthOtTM8tJCX93MumRGDbkly4wZt0iucmqc7NYhWQfmwPBP+qVBEyXJneVOag6FU7OozyMoQ4e3274ka52w==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -655,9 +655,9 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/animations": "16.0.3",
-        "@angular/common": "16.0.3",
-        "@angular/core": "16.0.3"
+        "@angular/animations": "16.0.4",
+        "@angular/common": "16.0.4",
+        "@angular/core": "16.0.4"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -666,9 +666,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.0.3.tgz",
-      "integrity": "sha512-40z8aRCZeMfT8iK4obsY/m91NI5PTW2KS51j+rswctne7i2g3MPLJDcAuTkClIR3Gj9x54qXwR5Tjdsx/r/Lsg==",
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.0.4.tgz",
+      "integrity": "sha512-AsyC4tXW2ddIrVNZANqWocdtYP/xMq79ZeDSlQSfxuPt3wvqx+bFOGMDJva9fIW6yBz4forOUKdnpyH4M9aegg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -676,16 +676,16 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "16.0.3",
-        "@angular/compiler": "16.0.3",
-        "@angular/core": "16.0.3",
-        "@angular/platform-browser": "16.0.3"
+        "@angular/common": "16.0.4",
+        "@angular/compiler": "16.0.4",
+        "@angular/core": "16.0.4",
+        "@angular/platform-browser": "16.0.4"
       }
     },
     "node_modules/@angular/router": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-16.0.3.tgz",
-      "integrity": "sha512-0ckLBbpMi0F7o5sJKis5kWxu7UzkJa4/5K3pDEFd301Ira8c/9LiSMqtFZ1bLGKVjwlpNJKnkq+k0KfmyyGHMw==",
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-16.0.4.tgz",
+      "integrity": "sha512-RgmY/dH5IB3aEnulqWHWSJ9TlcdOe7ZXOu1Fztmm3hk9brXyX5OB7R9sLG77yrE0eGDhdBJjgkLjmWPfjXurOA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -693,9 +693,9 @@
         "node": "^16.14.0 || >=18.10.0"
       },
       "peerDependencies": {
-        "@angular/common": "16.0.3",
-        "@angular/core": "16.0.3",
-        "@angular/platform-browser": "16.0.3",
+        "@angular/common": "16.0.4",
+        "@angular/core": "16.0.4",
+        "@angular/platform-browser": "16.0.4",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -1457,9 +1457,9 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0.tgz",
-      "integrity": "sha512-ha4zfehbJjc5MmXBlHec1igel5TJXXLDDRbuJ4+XT2TJcyD9/V1919BA8gMvsdHcNMBy4WBUBiRb3nw/EQUtBw==",
+      "version": "7.21.10",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.10.tgz",
+      "integrity": "sha512-3YybmT8FN4sZFXp0kTr9Gbu90wAIhC3feNung+qcRQ1wALGoSHgOz1c+fR3ZLGZ0LXqIpYmtE6Faua6tMDarUg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
@@ -2946,9 +2946,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.41.0.tgz",
-      "integrity": "sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.42.0.tgz",
+      "integrity": "sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2961,9 +2961,9 @@
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -3185,761 +3185,761 @@
       "dev": true
     },
     "node_modules/@material/animation": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-kOba/FmgxMNWL7Zgyma7Ar0vsF+M/lu089qOeAviD/ccohYatmsr0LGaqFZL+M1AjnW9wXOoBtJXPF2kFii5AQ==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-tr1y4KYZ2Ml9lFU9b91r5jivDCbh0N3Zv6VFe0frphztlZO5Lqx7MCxsliQ7NwQjqpXg3MkD6ZusVNvnMyo+LA==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/auto-init": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/auto-init/-/auto-init-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-MWH+0YdPr8a4FsJEkQC6nJ57WmPIqm3kS1WbROkSoxb/eZGECJCA6ajpWfgQtfjjKBrV217mRpen80Uf6fY9Kg==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/auto-init/-/auto-init-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-ZslBlje2LajaL5d7JCxUoWCKOBOsZYT33CamqPoDeY0Cjl77t3O+8B9YPHF8libytI8j9lrrDrTItQr53PHeHw==",
       "dependencies": {
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/banner": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/banner/-/banner-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-/tV7PDwmWMLQbyLjN2kuJvkAK2HyVCrmnd9ftcBoR02HGQ6uHGPiJYsP8Xw/ueBdpix2gM9ujtD6Vqby/Y6vMg==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/banner/-/banner-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-mVtGop9rBXRD6UYkMD7y+OJwd3MA73w7BJ/oJIKFij2q2fn/5hZba6vQ6d6YGUGv+iJPP/S/HaiMQuRE5yyoqA==",
       "dependencies": {
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/button": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/tokens": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/button": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/tokens": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/base": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/base/-/base-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-fObaR0dtmP8JrtZ0jzO28iP+TCn2RJzyOC1OHC7qyYOmGYw7MaHF9lArCdD++J93mhppTK3Fe+nOaBT6QkQW+g==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-DNelmohDScmGvWWS/J05dkIJb/dKOVkA6s0URgPrnTFKXNSavPsmwj7hWzYB5kusz3ZrXJBYBJsE6VqkRRXl0w==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/button": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/button/-/button-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-NrL9dJ364BJhf31+pffZw9iqOEM9pYxYshSH0xO9mjuo/F/VmPsFrUoK4PE+rx2/JltIhGJ+zaooZowEYIHlKg==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/button/-/button-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-m3YqCh33kcPGYehCKviDy7RxQIEM2m8Exo6AswPPsxd95jSN3rAeF+pXopoXW5QTOqyKHqHymTKTRYYvwvZHYg==",
       "dependencies": {
-        "@material/density": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/focus-ring": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/tokens": "15.0.0-canary.576d3d2c8.0",
-        "@material/touch-target": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/density": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/focus-ring": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/tokens": "15.0.0-canary.90291f2e2.0",
+        "@material/touch-target": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/card": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/card/-/card-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-lBwgu7wHjvS2LhiqsUBm+m6MEYMt74bON8GV6XCHXJYJK1Bvr7W5ib9D4KrOrEg9U2ksXK7i76b87c3yCuIRkQ==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/card/-/card-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-8Z8KQDmEIwt5IK0n+9C9Be9p4mWLKBXILbH+c6XcMCTemmUxH6cTTax1MwuAmqBGuIq3WE3g7qDpdzjFLTC2kw==",
       "dependencies": {
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/tokens": "15.0.0-canary.576d3d2c8.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/tokens": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/checkbox": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/checkbox/-/checkbox-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-eb2Mq0ME6l0o358/WSeRLzaSqj8YEDb1LLQZqivZQhcNV9NnqUtMEMx1UEEaH7RelbsSraqQAQQ8/zoKmDBZKg==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/checkbox/-/checkbox-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-hCilHX0vLedMgeRSOskf+JjdfLIUvEg597LEkTJHnTtJkhwypvol8OwP3eqz3TyJ3qGimIi/sFPKdMBn1Uk4AQ==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/density": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/focus-ring": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/touch-target": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/density": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/focus-ring": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/touch-target": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/chips": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/chips/-/chips-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-IvKmOpk8FHPzJXD19uHkPjmquQP6oerNh1QL2FdVm5+6dLt43CMVlCe8qzGorQofw3xWeY304aGL9eGEwuz51A==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/chips/-/chips-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-TMtlzuadWP/YMRYg8mpqmaD9M9GzRL5ulHHgYO5F4kaZmI3L+3zvaPvUme/x5qwPkIJUO9S21NxxGAsp9X+ZJQ==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/checkbox": "15.0.0-canary.576d3d2c8.0",
-        "@material/density": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/focus-ring": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/tokens": "15.0.0-canary.576d3d2c8.0",
-        "@material/touch-target": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/checkbox": "15.0.0-canary.90291f2e2.0",
+        "@material/density": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/focus-ring": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/tokens": "15.0.0-canary.90291f2e2.0",
+        "@material/touch-target": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "safevalues": "^0.3.4",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/circular-progress": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/circular-progress/-/circular-progress-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-J4yrTYftgDiw1buLPSPQKp6FRhgQ0RU6WEHX1OIy6RL0AySSsOB6eDAcVzOg5enWsXBtSsEwjNLXTb5UmHtilA==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/circular-progress/-/circular-progress-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-znCz3cXC8rmC+1k1ZEeZNOhngm7O7kVG2PoANaE79NN9taDtCTyBGGeocJ4Kza3tb01vxJ2/tuQXC39GNFkHFg==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/progress-indicator": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/progress-indicator": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/data-table": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/data-table/-/data-table-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-E3K8exa8ihrUFz61gUvJ9zwqcLwHY4k5vcHiqKhf9Sa4Lqgy7FQmd+EMckr0X62aaj+RqmJdahiJoWDFBx7LVw==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/data-table/-/data-table-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-9YU6KkOeKs2ARPXZdg7Cv6nPwLkEyBIN331ZB92apcbQpTMJMhR3uuW8SSw4p7aXCE6CJjREsCc0KuYAnFSa2A==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/checkbox": "15.0.0-canary.576d3d2c8.0",
-        "@material/density": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/icon-button": "15.0.0-canary.576d3d2c8.0",
-        "@material/linear-progress": "15.0.0-canary.576d3d2c8.0",
-        "@material/list": "15.0.0-canary.576d3d2c8.0",
-        "@material/menu": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/select": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/tokens": "15.0.0-canary.576d3d2c8.0",
-        "@material/touch-target": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/checkbox": "15.0.0-canary.90291f2e2.0",
+        "@material/density": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/icon-button": "15.0.0-canary.90291f2e2.0",
+        "@material/linear-progress": "15.0.0-canary.90291f2e2.0",
+        "@material/list": "15.0.0-canary.90291f2e2.0",
+        "@material/menu": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/select": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/tokens": "15.0.0-canary.90291f2e2.0",
+        "@material/touch-target": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/density": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/density/-/density-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-seBxT1LkU4jhzyeP1yT1coWXs0QGhwmwfeZOCx2YG2RmHD8a+ucf0y4BjWGDQSc4B9nudeIOYkXEUMfSdjRoQA==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/density/-/density-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-z2L49vc5tbIGe7tUHwbmzoPvOugsTNVP24WWwBwtg9PRuK4Td5HIsMGYqSzSuwFJvDWQK9Ugvl37jGZSv4vxog==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/dialog": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-12rNdRft1iKpZQLCVlYK3f314wFU1KlF6Ejbx8wT6dz4mrNhgYYoxjOOpL0D/Ys1iMR2EUBJOHdv7ghU/ApcGA==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-n0o4MELpVqJHbJDPBYeXf3xeL9a8hbzHmfXYLDI1MUhDIr4xgSkckKdCRc2IFda/g7kxjAgcUTga9EFWqns2qA==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/button": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/icon-button": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/tokens": "15.0.0-canary.576d3d2c8.0",
-        "@material/touch-target": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/button": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/icon-button": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/tokens": "15.0.0-canary.90291f2e2.0",
+        "@material/touch-target": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/dom": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-oo8vmADL6Z26iCWG7PEvUYEeVWXufETGHYVbWIEPGCr7uzB6j4Apb+JDKn0h3yMP33t7VJibQTBkA5q5Y4Vtxw==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-90JKk/Ncnqn2dKopNxs1uruiiQZzgLTZQF3a8jxa/w3RQd3Ac9ET1KqmaJSfzXaxgebm+1RZfL9lL+ANEfLWwQ==",
       "dependencies": {
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/drawer": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/drawer/-/drawer-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-+y+DaXemENGgouy0qzP8XhcO+n57V40lyzHd5lZ7MaTSy7VcgKUjIoAX/aTGKjbh/jFk+fuQZeCwC8D0oAZz8g==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/drawer/-/drawer-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-7MJbjUxqpQG9J52xWGVKRhSI/0/7Uhf7l2P9VI2WFb5Fz0IeUupXlw2k1Ktb97nxSjMe9OazjtVUgzBNwOad/Q==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/list": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/list": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/elevation": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-9jMCY7Wwbo2FBzXKM2InxgsGvflOGPm/ZeUAZ5OtIV3WSvj/nI08FxPcZFwUJvWvyB3OgwSVAWPfT0gsD1sUHQ==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-4eYbCDc6IfgfguNmRc5GT4QMCfOEwj+K3BAraABcbpuCzEQ5nCClsVrPbRLfPnhWbQrFc2/eBglB8wsrNTjVBw==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/fab": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/fab/-/fab-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-5t8QDhDbdRelLiQbPHWh/M36Q4LNPMRqBnoA3V3r2H7+zOVhA5msqi8GLp2zx+cW6oAQjrs6QF9fMLOkXX8qgw==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/fab/-/fab-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-YJuJRdqe57DnJ4qyc04flknuGeN+7Nc9ciFZE6snPn84wD6J1khscb21yRARbALDki18kbfnJNrNbzHkYaEMZg==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/focus-ring": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/tokens": "15.0.0-canary.576d3d2c8.0",
-        "@material/touch-target": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/focus-ring": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/tokens": "15.0.0-canary.90291f2e2.0",
+        "@material/touch-target": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/feature-targeting": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-i93vd9JZj5mDCzSrIAJjnuwySo/zkf3S+TmCcOb5vp/8R6Tkj5djTZt067PIUX+HN17Ukit7NSpSVTbJjAsaBQ==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-mjUemPnMLXPooDcPHxxc2uhVUzm7X3NDsE0x0QJnsHDwuejakaRLghVcRDX3x1VmL/p52Eu5HrgW2FryFEiVhQ==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/floating-label": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-5NX6px0ndc51rRg/OcmehTpXrSuwmdsblpkHLxzYeeDKygBzGz+5ixfRSa8QWoHifEZdcTaUNsz5G7vQPngHdA==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-dYtgNlXkO0H9Vn76oESZZg1KOa2XIOLhVxhV/qPYrhntET534i7TyajmVk54ncuSSoLPZrbrwrhhR2fUJWxZIg==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/focus-ring": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/focus-ring/-/focus-ring-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-dV0UnsKyYhF3SUcRhWdcyYtO/2GkOLcANq+iujDywfMuqQfo48ui8fA1x9C8Jl7LJPVTNvRjiI4kEsWJya273g==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/focus-ring/-/focus-ring-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-U7ERDgHi33ZRmqsiO6syFaWsCUGneltX2sYVtLpQnxME7pKFzi22GdUUIslhgHOFjSMBFF9av2Y79VFbyj9BaQ==",
       "dependencies": {
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0"
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0"
       }
     },
     "node_modules/@material/form-field": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/form-field/-/form-field-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-4c00pPlVwx8lvfYO28Ato+WcA9HmKmU5NmmPrYuifMxGpz8BwHPL3369wsE40qkgZt8bvtwVE2lDcij6kJ434g==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/form-field/-/form-field-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-KTj+EOobLcPUYy4nR+t0c2Cjvs7jCI4F1w8XuV0bbmSa6Sxh02tMKY2Xa7Lx55A/uUrsUfViMdP60OLzi7HgjQ==",
       "dependencies": {
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/icon-button": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/icon-button/-/icon-button-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-Wer60ASSo7nj2xXcJRUTFbm6uiKVvtpuoAn9a7SvtNYDLPGBTCmDDxI0VEXjDfTMSPhpxIo92i40gl5Hk0fsKQ==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/icon-button/-/icon-button-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-bpqiVPkf/LJEP7iIV5VL9Th0chCIQKTeOuw0mK8HmYucuvqq+k76oPsUcE7mvxRvuKyVh6KJ9fTHAkjse0y7cg==",
       "dependencies": {
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/density": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/focus-ring": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/touch-target": "15.0.0-canary.576d3d2c8.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/density": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/focus-ring": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/touch-target": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/image-list": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/image-list/-/image-list-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-veGiP8W43sHWhny8enHNXLaPkvubjgh5NzJOryfTyHb+Ixyfr6/FYCtNGtRgTkNiy7nRye33mMaNqQ/oRyN/LA==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/image-list/-/image-list-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-JobM4lWsf9grgbqrLuUtJ5fr8BkG02r9c2oFMl5++dtjtLdXWnUIWbiofna8CeqDFQCKXsCk4Jw8ydSKZvj/3A==",
       "dependencies": {
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/layout-grid": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/layout-grid/-/layout-grid-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-Vxh2Lyv0XvkSFuzio6PmooZtDVFyhFXAhTXWhvxYBgTPyrYB8lsUcWRwHJZEkKuz3Sti7WKtF5rqv+p3KGy01A==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/layout-grid/-/layout-grid-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-f5DSHGf1ka6vHu+8VoTvcU9NkR8fdN2wHmPnITZHQXPVvR6SKoyDzdAf2gacmiTYy69ZFmmJeMcdfNnbcPPUJw==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/line-ripple": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/line-ripple/-/line-ripple-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-NnHk935Ae39eH4Ac7aR0GKIUd3/7WkV5VRW/SXdwTaEie0hLK9+AGXkhJH0U6pmmWmM7moJNRFXZMSv5oavkBw==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/line-ripple/-/line-ripple-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-cWpS7l/pFg6cUzL7Lx3ywF6RYF6ESYPkiGlDo9kFERv8lVA2/3m4NF4d9b4kC9h9OWx1b1CaUFRFGD07okgI+g==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/linear-progress": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/linear-progress/-/linear-progress-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-yuvhPo1n8J7C+VtzP2RjqNfyiApx2k2W5g7zVAWmfDJbvqtPqciO8rqKhrQM67ZfpfseA1HgG1kVqigbxi4ERg==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/linear-progress/-/linear-progress-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-nK5RYn8NFZi/+fznLYoEdY6tSzXiJqOU0tX5by7hStURhP2g/RM5SQaJwyjEmHdorfCUIStgmKsN4rB5aMnxdw==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/progress-indicator": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/progress-indicator": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/list": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/list/-/list-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-MPEC640uS3i6fvRSWaUetErAeRsqyqlM6l59/pf9EY1+L/gV6tFheb07/nj41l0sI6BbUr+qR1j98Ybj/8pKQg==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/list/-/list-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-h2c6G5aPH1bhgl2yBYAW4y86pl+yVl3YdqU0ixemQ5/2uB/t92imUbI+gKH5LzlbuJKenk3rZJ5eaV+t5zTS1A==",
       "dependencies": {
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/density": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/tokens": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/density": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/tokens": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/menu": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/menu/-/menu-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-l/PQjH78oLnMBBzRavPAarsqT567dDnglaLMhlZHHcgpzWdGQreJ/kIPoaMr/VPaIAAwjQfivNUaIb17+3mLEw==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/menu/-/menu-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-yfpBN4Hg59pHMNplh2LIe8t+/qsfyP0iRAtJoCK90SBwX43kv65u22+3vEJmYzm3Ey/m3S3YRFXTFQRQnn9cmA==",
       "dependencies": {
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/list": "15.0.0-canary.576d3d2c8.0",
-        "@material/menu-surface": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/tokens": "15.0.0-canary.576d3d2c8.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/list": "15.0.0-canary.90291f2e2.0",
+        "@material/menu-surface": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/tokens": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/menu-surface": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/menu-surface/-/menu-surface-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-BLTOgfVR96uRE5vvXy+ZO7A/NgzMjT7YhxRbODYv+vSi46Gmdyx09GQcOKMUZspat9vNRqh/AYSXpJ6j5E9U2w==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/menu-surface/-/menu-surface-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-AkRpOjFOJi2ROZPvFo1z8ik61eEyJEew8NuvlzCE4S3BX/RNFrYVh4W5ylo030S01ALCS5zhVOeekxa/4eokZA==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/notched-outline": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-+l3AHq8JuNBz4J0d5jsWAueghwnzAASMq7BIqrZUMEfyCSG3MJ2Pzzj5AMLyqFvb6IMMSqbNozgkVwtD/Qh8SQ==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-4lpoIoFJ8cb++M1iQpZ+8iypUuTruzyBAkOvoaNjk7EftEV+aS3K6XntGNtlUZoB/fFho3mAUVjT19IHFWD03A==",
       "dependencies": {
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/floating-label": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/floating-label": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/progress-indicator": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/progress-indicator/-/progress-indicator-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-Id+ie1pRQRbaglj8P/LAB7wIuQf5zlwuMw6MhefjkgXRXg5GkJQIeE4EQOzVhDQUkvLOBapKP8gRMs7t9TwHPg==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/progress-indicator/-/progress-indicator-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-trQLSstZIA0C64adW/HycycD+PtMfg6iZCIVuTNlZr7PR2Yc1EjuGyA7ts+iXBHZ0TxVshRbDYMwcDogP0rc1w==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/radio": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/radio/-/radio-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-/BpEL6YWKM+7c4dWqOcSM8wbfz1K3g3r+q+r1ReBKlvUh+Uhz++PW6qjMxPTPNt7a+yzH9/LkXMRZan9/+pjxw==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/radio/-/radio-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-Ypl4BZ9w1NdbiiEUV3Xw2pb97prMPGEE+5Lm719sVsaFmI4yCKgtsWNEbCbKixborh2ZDZWGCzgMyUQHf3a8xA==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/density": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/focus-ring": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/touch-target": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/density": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/focus-ring": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/touch-target": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/ripple": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-YewgiAu6fmHLiJrML2sWeNXYZB4ooCY8m+mMl2eSsAq0YDpIFL8gsrgPAAKete5J9ASbF6id1jsm0pyoM6AO1g==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-8yCR/V+7SJ9om0cvAOULF/i5+gPQeT+cuPoCZJQRWq9IndfCmQPY3Zmy26reIT/zEyCebAvMG4/WtU4rc+jxyw==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/rtl": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-LCVuYdauCQ7+SD1h+rrqRazP9ownLDsq0XSgbRZXFPAVq8ED8FDvlK8+Ustu4/slLNBq3F78M6SlzOWyCnErRA==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-HkUhD8K03BxWVw21WDViWo01Chi22cZ1rmlsdCtggkxdVjtDhTbYm/3XvRnxt4RVpr6KaYQgRXI/52T5RtBUnw==",
       "dependencies": {
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/segmented-button": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/segmented-button/-/segmented-button-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-XGluudwIFds1XU+W+C+5pxTP5z8t4wn4UC24RCbMG2AhmeF3cP+iou1eL9gRT/OQ5YYG+E+tB7UeTQUXpxIVcA==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/segmented-button/-/segmented-button-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-u1DF+jbysX6wCqt7dDnHgEo2XhNrwkqHq6YsMOFVCoo54PHt3gpwhD89DONqQJKspkdvZuxYHzpqRtV0GIzYDQ==",
       "dependencies": {
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/touch-target": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/touch-target": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/select": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/select/-/select-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-4HBxKVgsEdTRUZo7ciH2rGUMnE2dmKzGo2XGK1yQadbS26Dn3uIJV92xvn+fv5eoHWvYcHrcq1/7pH+JhuAogQ==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/select/-/select-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-CCaftyi3eIJl2XqBfHbzj8W2jgTMBzSM2+q4WthA+7z0fYQI4JIHQVHO5YKQG5J9MR1VjYQ0Gy0GNotZLAcoOQ==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/density": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/floating-label": "15.0.0-canary.576d3d2c8.0",
-        "@material/line-ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/list": "15.0.0-canary.576d3d2c8.0",
-        "@material/menu": "15.0.0-canary.576d3d2c8.0",
-        "@material/menu-surface": "15.0.0-canary.576d3d2c8.0",
-        "@material/notched-outline": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/tokens": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/density": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/floating-label": "15.0.0-canary.90291f2e2.0",
+        "@material/line-ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/list": "15.0.0-canary.90291f2e2.0",
+        "@material/menu": "15.0.0-canary.90291f2e2.0",
+        "@material/menu-surface": "15.0.0-canary.90291f2e2.0",
+        "@material/notched-outline": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/tokens": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/shape": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-AYcQjpeWq/lJoBtUdjSeOf9nVCqGrsNTzuBqwKcQ+bPHkhHsD8h5YK6yD//DR2fTT0TFidvOY3NsYqcP460B0Q==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-UEB168x8ovLvH4eoBtRnoCT9QvnxB/ZMpOKW1+C+xWisis6Wy9AX0wKT5T6wIpffYYCaBJuhI+ExX2134rAxJw==",
       "dependencies": {
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/slider": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/slider/-/slider-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-80GPBNJXWO3tCK95P49H+Ru/+Q6E6NNwGgZHx6L5ADFKJt5k6jZLwjZ1DlX5kqD10WpV3qVggSxbP9/TgGdNAQ==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/slider/-/slider-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-krbdGHcROlvnZ0X7HT0d+PvJummczeShQeWeV/ZezXnQM7bQoy86qfwtX4ai1dIXYkF9qKTFlta2zZezTJyf5g==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/tokens": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/tokens": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/snackbar": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/snackbar/-/snackbar-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-aOPR54EI1BrlompgcWcYtCgGHvd+mtvHrgcbvHbB1BxqIVG7X6N2gJ/8I4yzDNjXbxlu0hPVSsVRwhuvlF6NcA==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/snackbar/-/snackbar-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-f1+HaSaAkALtQqEr6WMUqfwOsJr5nOUjP15GA+sTs9SD7yzwqMeWsVriBdWXVRe0zNgew6sfBM+cLjg2w4VAOQ==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/button": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/icon-button": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/tokens": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/button": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/icon-button": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/tokens": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/switch": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/switch/-/switch-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-WSOdXZJotvxhAsWxhvaBHXC5sGRSWxkyAX1lCg39y5NisopiKSNlPWgZcl++yyFKVhpoYzYVV7yGynRWFj/VWQ==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/switch/-/switch-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-94/+Zp2VjlLVJXY7u8VHPcJMHPRVNAwHydiGrKvnJ+6LfbLxAcILNBP9RVKqqqOWQeDxB4ApUl+0TV2Lj6mOzA==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/density": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/focus-ring": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/tokens": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/density": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/focus-ring": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/tokens": "15.0.0-canary.90291f2e2.0",
         "safevalues": "^0.3.4",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/tab": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/tab/-/tab-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-3crRmZpIG6qRByPr784Cy2Yi714+YLAXD3q1PGcrb2dqNl/ckFBS3JnwkfvDYTTOBz+sOkVcDIbadAUivnqWZQ==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/tab/-/tab-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-zju6UP038Ddi3XAfliYy58A3OvkQ+zSlOdNOd5l82oMArLYEFi3t51QTjKVjV1wokr6ZQ3Chs4kcrgwVTElYtg==",
       "dependencies": {
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/focus-ring": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/tab-indicator": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/tokens": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/focus-ring": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/tab-indicator": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/tokens": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/tab-bar": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/tab-bar/-/tab-bar-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-CuBJe4jt3mOO7zUy8tpUZizeac76AP2Scw/R8GZCArj+tW/Sxtx+J0VAMMzpLrkxChbflLKdKj7/vehvt1dRpA==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-bar/-/tab-bar-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-dTC7oGZg6KuDK2OXO7luJWqshtNY2YgImwZbQ9a1vZZrIGMRHdu+ZtP6RVH2srFVlNIWjzcxfLgNrG+U027RdA==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/density": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/tab": "15.0.0-canary.576d3d2c8.0",
-        "@material/tab-indicator": "15.0.0-canary.576d3d2c8.0",
-        "@material/tab-scroller": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/tokens": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/density": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/tab": "15.0.0-canary.90291f2e2.0",
+        "@material/tab-indicator": "15.0.0-canary.90291f2e2.0",
+        "@material/tab-scroller": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/tokens": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/tab-indicator": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/tab-indicator/-/tab-indicator-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-zPGeBimy+mG0Eo2wc83aKS8cdiyQM7RZW0BFl570BGejzjTRWoW3hoQTqKj/3Ha7/jcN+kMHMFpsNr8toWGC4g==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-indicator/-/tab-indicator-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-GXdFO6rO1crXcj+todijzZQVACW4EC72XwLAl6z69TKBgZrhwCoZ6RgzX6vIXSs+KoZ0eIyQLr+yQQx1JjDd4w==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/tab-scroller": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/tab-scroller/-/tab-scroller-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-8ambIVmtdrKgSirGxVYJEDaXOQE81m3lJrPp8hBjuQeo8m6+769mb1cXf7uvUazsuHTQPl7BAxrd+BF5b+v32w==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-scroller/-/tab-scroller-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-R6trOZpkfk54VV0w0NjMMDcZPQgbnARxCoHLrWeSzv5KOMoiDyWji7FFpLc4fynX/F2lNg8xHpEolpugNRW/1g==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/tab": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/tab": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/textfield": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-Pyd+xyKXrAbsvE5Prh2A0QvzMLvK5toBGsVGkwU/Y3qzu0lZQpd4uxgCGFau0/Ni8Jl58CNxmPTFnT69MLgM9Q==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-ipxPH8DRh9+cn4MOtAYvGsRLP5RJH/gB/BWh/BiJwjI38Djt4FK4LDHbx7fFo/C8hoj7UNs/BWaSLllyxuWKcg==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/density": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/floating-label": "15.0.0-canary.576d3d2c8.0",
-        "@material/line-ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/notched-outline": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/tokens": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/density": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/floating-label": "15.0.0-canary.90291f2e2.0",
+        "@material/line-ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/notched-outline": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/tokens": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/theme": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-wD3N8+2uqyRc9K1q3Q5YvTKgbecSFQuJGQeQFsHKNsshuqm0lQgserWs5ECHJ4NKihAceR4y+9K6tFlutnd2UQ==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-rDSZ0bPoJothI8nRPQWB4Cyu7DTmc8qIuvFm3OOD4uI/2n+yIFqktS6X+6YF82LeKt4uMTZE+Ce/l51bb8UJGA==",
       "dependencies": {
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/tokens": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-Gg864O9D+hEPm+el/rl9gGo9JoMdNV1imqBr3pQR1NbH8Whn2qSUl7JufVOz1qe4WwU5wzV2bqXfEVI5/R37Ug==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-ZTis8UeSRrm/4iQ6BujtcTf1J2bs2H+SAEnugtZSQiX8pyf90gQvylEoTuMPdUs1+YJ273cn04ipHdkq3OHaew==",
       "dependencies": {
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0"
+        "@material/elevation": "15.0.0-canary.90291f2e2.0"
       }
     },
     "node_modules/@material/tooltip": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/tooltip/-/tooltip-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-jLqEOTSaGY2iezoNnbvgmbHh+U+4KXaL1WvCwWrrzuaq+d204pEFfuhnIrFksChgn/vTKLbBJ08j41Dxv483mg==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/tooltip/-/tooltip-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-H3XsrctgRriNwt++NN+Zy6/JhyRznWo2pXiTFnOlaYwHOiGIFCNZR0A/0vf/3Kpf0GYhTfkJEFJMosUSZidSDg==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/button": "15.0.0-canary.576d3d2c8.0",
-        "@material/dom": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/tokens": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/button": "15.0.0-canary.90291f2e2.0",
+        "@material/dom": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/tokens": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "safevalues": "^0.3.4",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/top-app-bar": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/top-app-bar/-/top-app-bar-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-3GSVTPiK0dpexfIxImg7He8WWzTJ94Su+WuKhCHMBUsnc1jeMWD22fNBXo0HrEBK6+4U+4PxJXgrGE9xI3uzug==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/top-app-bar/-/top-app-bar-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-ZiJjK4WpIsE0MZTWokP9r4C9/oDqzUhKRn3ef2WCeJEIU3Vjg4t0xBTnST2vIrcBGw1s7WP1gfaxb3DSXSxzpw==",
       "dependencies": {
-        "@material/animation": "15.0.0-canary.576d3d2c8.0",
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/elevation": "15.0.0-canary.576d3d2c8.0",
-        "@material/ripple": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/shape": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
-        "@material/typography": "15.0.0-canary.576d3d2c8.0",
+        "@material/animation": "15.0.0-canary.90291f2e2.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/elevation": "15.0.0-canary.90291f2e2.0",
+        "@material/ripple": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/shape": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
+        "@material/typography": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/touch-target": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-wCJSv1yPnD2CQN9r24MBWTFL3+xJOsFo9W/3jPpipvTGi16Nq5ce0Fr6gw7Y/hVUfkqSdKudly9bTNTJnmhglA==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-IpRFf4umZ4ZNxrP+qJkRY9syh7TFZmU4c7EbAlANAJ0/8rlkEo7WJiqa9P1p4nFaT4eMo4n5g+qRI0Dkb9zW5g==",
       "dependencies": {
-        "@material/base": "15.0.0-canary.576d3d2c8.0",
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/rtl": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
+        "@material/base": "15.0.0-canary.90291f2e2.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/rtl": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/typography": {
-      "version": "15.0.0-canary.576d3d2c8.0",
-      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-15.0.0-canary.576d3d2c8.0.tgz",
-      "integrity": "sha512-hScFlyRZ8Qv/jL5rihhs1SR/wt7yGIq8KLYObi45LhMHHEl3s+otGcg8JmWrD+xZufVz/pemRlNJ9wlM+yO4rQ==",
+      "version": "15.0.0-canary.90291f2e2.0",
+      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-15.0.0-canary.90291f2e2.0.tgz",
+      "integrity": "sha512-tv1HWkJYi5T0470k8vbBb+nefdPgsaIO04ocWMf7luvmfE+MZIaR13RxdupLJ4k5otrdydL3/wEaCNhQ+Ipnvw==",
       "dependencies": {
-        "@material/feature-targeting": "15.0.0-canary.576d3d2c8.0",
-        "@material/theme": "15.0.0-canary.576d3d2c8.0",
+        "@material/feature-targeting": "15.0.0-canary.90291f2e2.0",
+        "@material/theme": "15.0.0-canary.90291f2e2.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.0.3.tgz",
-      "integrity": "sha512-OtTKgv6wgRwbLD0WkOqLYRFKrYKH4luiCSzzTqlJuCIKrPI+7+L1rH5I0zWzkTYzGFGTAgP5BGRiY19gFS3/BA==",
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.0.4.tgz",
+      "integrity": "sha512-9slmfDGE9l8S4PQlRoCjkVyzKzWVONgceb7Af85vZLcMhY6pa7f0/ddD586XpJBFXsP0xypEi9Tc8+Ld6Tdw5Q==",
       "dev": true,
       "engines": {
         "node": "^16.14.0 || >=18.10.0",
@@ -4462,13 +4462,13 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.0.3.tgz",
-      "integrity": "sha512-aWRVvgOTMxsaY6FETd+1L4YvqAjfIRSmB3yqfRXpzEdUelAkYozg0lWDHS6q6u6YlfCIUnEw0oUTJG3m8JSF4w==",
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.0.4.tgz",
+      "integrity": "sha512-3uu5xq136broqVKCGwYKENZYF8SO4EU15FHRV2EFY/PqU2sU5QBlsGG2Z1JYAVE3aevsk9ORkPb1tRh6yP28Rw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.0.3",
-        "@angular-devkit/schematics": "16.0.3",
+        "@angular-devkit/core": "16.0.4",
+        "@angular-devkit/schematics": "16.0.4",
         "jsonc-parser": "3.2.0"
       },
       "engines": {
@@ -5398,9 +5398,9 @@
       "dev": true
     },
     "node_modules/@yarnpkg/parsers": {
-      "version": "3.0.0-rc.44",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.44.tgz",
-      "integrity": "sha512-UVAt9Icc8zfGXioeYJ8XMoSTxOYVmlal2TRNxy9Uh91taS72kQFalK7LpIslcvEBKy4XtarmfIwcFIU3ZY64lw==",
+      "version": "3.0.0-rc.45",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.45.tgz",
+      "integrity": "sha512-Aj0aHBV/crFQTpKQvL6k1xNiOhnlfVLu06LunelQAvl1MTeWrSi8LD9UJJDCFJiG4kx8NysUE6Tx0KZyPQUzIw==",
       "dev": true,
       "dependencies": {
         "js-yaml": "^3.10.0",
@@ -7261,9 +7261,9 @@
       "optional": true
     },
     "node_modules/d3": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.4.tgz",
-      "integrity": "sha512-q2WHStdhiBtD8DMmhDPyJmXUxr6VWRngKyiJ5EfXMxPw+tqT6BhNjhJZ4w3BHsNm3QoVfZLY8Orq/qPFczwKRA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.5.tgz",
+      "integrity": "sha512-JgoahDG51ncUfJu6wX/1vWQEqOflgXyl4MaHqlcSruTez7yhaRKR9i8VjjcQGeS2en/jnFivXuaIMnseMMt0XA==",
       "optional": true,
       "dependencies": {
         "d3-array": "3",
@@ -7702,9 +7702,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
-      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.8.tgz",
+      "integrity": "sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ==",
       "devOptional": true
     },
     "node_modules/debug": {
@@ -8101,9 +8101,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.414",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.414.tgz",
-      "integrity": "sha512-RRuCvP6ekngVh2SAJaOKT/hxqc9JAsK+Pe0hP5tGQIfonU2Zy9gMGdJ+mBdyl/vNucMG6gkXYtuM4H/1giws5w==",
+      "version": "1.4.419",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.419.tgz",
+      "integrity": "sha512-jdie3RiEgygvDTyS2sgjq71B36q2cDSBfPlwzUyuOrfYTNoYWyBxxjGJV/HAu3A2hB0Y+HesvCVkVAFoCKwCSw==",
       "dev": true
     },
     "node_modules/elkjs": {
@@ -8381,16 +8381,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.41.0.tgz",
-      "integrity": "sha512-WQDQpzGBOP5IrXPo4Hc0814r4/v2rrIsB0rhT7jtunIalgg6gYXWhRMOejVO8yH21T/FGaxjmFjBMNqcIlmH1Q==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.42.0.tgz",
+      "integrity": "sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
         "@eslint/eslintrc": "^2.0.3",
-        "@eslint/js": "8.41.0",
-        "@humanwhocodes/config-array": "^0.11.8",
+        "@eslint/js": "8.42.0",
+        "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
@@ -9349,9 +9349,9 @@
       }
     },
     "node_modules/fs-monkey": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
-      "integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.4.tgz",
+      "integrity": "sha512-INM/fWAxMICjttnD0DX1rBvinKskj5G1w+oy/pnm9u/tSlnBrzFonJMcalKJ30P8RRsPzKcCG7Q8l0jx5Fh9YQ==",
       "dev": true
     },
     "node_modules/fs.realpath": {
@@ -11815,9 +11815,9 @@
       }
     },
     "node_modules/memfs": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.1.tgz",
-      "integrity": "sha512-UWbFJKvj5k+nETdteFndTpYxdeTMox/ULeqX5k/dpaQJCCFmj5EeKv3dBcyO2xmkRAx2vppRu5dVG7SOtsGOzA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.2.tgz",
+      "integrity": "sha512-4kbWXbVZ+LU4XFDS2CuA7frnwz2HxCMB/0yOXc86q7aCQrfWKkL11t6al1e2CsVC7uhnBNTQ1TfUsAxVauO9IQ==",
       "dev": true,
       "dependencies": {
         "fs-monkey": "^1.0.3"
@@ -13749,9 +13749,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.1.tgz",
-      "integrity": "sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
+      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
@@ -14204,9 +14204,9 @@
       }
     },
     "node_modules/read-package-json": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-6.0.3.tgz",
-      "integrity": "sha512-4QbpReW4kxFgeBQ0vPAqh2y8sXEB3D4t3jsXbJKIhBiF80KT6XRo45reqwtftju5J6ru1ax06A2Gb/wM1qCOEQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-6.0.4.tgz",
+      "integrity": "sha512-AEtWXYfopBj2z5N5PbkAOeNHRPUg5q+Nen7QLxV8M2zJq1ym6/lCz3fYNTCXe19puu2d06jfHhrP7v/S2PtMMw==",
       "dev": true,
       "dependencies": {
         "glob": "^10.2.2",
@@ -16173,9 +16173,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
-      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular-material-components/datetime-picker": "^9.0.0",
     "@angular/animations": "^16.0.0",
     "@angular/cdk": "^16.0.0",
     "@angular/common": "^16.0.0",

--- a/projects/angular-intl-demo/src/app/pipes/date-utils.ts
+++ b/projects/angular-intl-demo/src/app/pipes/date-utils.ts
@@ -1,0 +1,4 @@
+export const getDateString = (date?: Date): string => {
+  const newDate = date ? new Date(date) : new Date();
+  return new Date(newDate.getTime() - newDate.getTimezoneOffset() * 60000).toISOString().slice(0, -1).split('.')[0];
+};

--- a/projects/angular-intl-demo/src/app/pipes/date/date.component.html
+++ b/projects/angular-intl-demo/src/app/pipes/date/date.component.html
@@ -1,9 +1,10 @@
 <div class="fields-container">
   <mat-form-field>
     <mat-label>Date</mat-label>
-    <input [(ngModel)]="selectedDate" [ngxMatDatetimePicker]="picker" matInput placeholder="Choose a date">
-    <mat-datepicker-toggle [for]="$any(picker)" matSuffix></mat-datepicker-toggle>
-    <ngx-mat-datetime-picker #picker></ngx-mat-datetime-picker>
+    <input #picker [(ngModel)]="selectedDate" matInput placeholder="Choose a date" type="datetime-local">
+    <button (click)="picker.showPicker()" mat-icon-button matIconSuffix>
+      <mat-icon>today</mat-icon>
+    </button>
   </mat-form-field>
 
   <mat-form-field>

--- a/projects/angular-intl-demo/src/app/pipes/date/date.component.ts
+++ b/projects/angular-intl-demo/src/app/pipes/date/date.component.ts
@@ -1,5 +1,6 @@
 import {Component} from '@angular/core';
 import {languages} from '../../languages';
+import {getDateString} from "../date-utils";
 
 @Component({
   selector: 'app-date',
@@ -8,7 +9,7 @@ import {languages} from '../../languages';
 })
 export class DateComponent {
   languages = languages;
-  selectedDate = new Date();
+  selectedDate = getDateString();
   dateStyle: Intl.DateTimeFormatOptions['dateStyle'];
   timeStyle: Intl.DateTimeFormatOptions['timeStyle'];
   hour12: Intl.DateTimeFormatOptions['hour12'];

--- a/projects/angular-intl-demo/src/app/pipes/pipes.module.ts
+++ b/projects/angular-intl-demo/src/app/pipes/pipes.module.ts
@@ -13,11 +13,11 @@ import {FormsModule} from "@angular/forms";
 import {MatInputModule} from "@angular/material/input";
 import {PipesRoutingModule} from "./pipes-routing.module";
 import {CountryComponent} from "./country/country.component";
-import {NgxMatDatetimePickerModule, NgxMatNativeDateModule} from "@angular-material-components/datetime-picker";
-import {MatDatepickerModule} from "@angular/material/datepicker";
 import {UnitComponent} from "./unit/unit.component";
 import {ListComponent} from "./list/list.component";
 import {RelativeTimeComponent} from './relative-time/relative-time.component';
+import {MatButtonModule} from '@angular/material/button';
+import {MatIconModule} from '@angular/material/icon';
 
 @NgModule({
   declarations: [
@@ -40,9 +40,8 @@ import {RelativeTimeComponent} from './relative-time/relative-time.component';
     MatSelectModule,
     FormsModule,
     MatInputModule,
-    NgxMatDatetimePickerModule,
-    MatDatepickerModule,
-    NgxMatNativeDateModule,
+    MatButtonModule,
+    MatIconModule,
   ],
 })
 export class PipesModule {

--- a/projects/angular-intl-demo/src/app/pipes/relative-time/relative-time.component.html
+++ b/projects/angular-intl-demo/src/app/pipes/relative-time/relative-time.component.html
@@ -1,9 +1,10 @@
 <div class="fields-container">
   <mat-form-field>
     <mat-label>Date</mat-label>
-    <input [(ngModel)]="selectedDate" [ngxMatDatetimePicker]="picker" matInput placeholder="Choose a date">
-    <mat-datepicker-toggle [for]="$any(picker)" matSuffix></mat-datepicker-toggle>
-    <ngx-mat-datetime-picker #picker></ngx-mat-datetime-picker>
+    <input #picker [(ngModel)]="selectedDate" matInput placeholder="Choose a date" type="datetime-local">
+    <button (click)="picker.showPicker()" mat-icon-button matIconSuffix>
+      <mat-icon>today</mat-icon>
+    </button>
   </mat-form-field>
 
   <mat-form-field>

--- a/projects/angular-intl-demo/src/app/pipes/relative-time/relative-time.component.ts
+++ b/projects/angular-intl-demo/src/app/pipes/relative-time/relative-time.component.ts
@@ -1,6 +1,7 @@
 import {Component} from '@angular/core';
 import {IntlRelativeTimePipeOptions} from "projects/angular-ecmascript-intl/src/lib/relative-time/relative-time.pipe";
 import {languages} from "../../languages";
+import {getDateString} from "../date-utils";
 
 @Component({
   selector: 'app-relative-time',
@@ -8,7 +9,7 @@ import {languages} from "../../languages";
   styleUrls: ['./relative-time.component.scss'],
 })
 export class RelativeTimeComponent {
-  selectedDate = new Date(new Date().getTime() - 60000);
+  selectedDate = getDateString(new Date(new Date().getTime() - 60000));
   languages = languages;
   numeric?: IntlRelativeTimePipeOptions['numeric'];
   style?: IntlRelativeTimePipeOptions['style'];


### PR DESCRIPTION
The used third party datetime picker is not fully compatible with Angular 16 and there are no signs that support will be added.